### PR TITLE
enable rga

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-nanopi4-common.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi4-common.dtsi
@@ -540,7 +540,7 @@
 };
 
 &rga {
-	status = "disabled";
+	status = "okay";
 };
 
 &display_subsystem {


### PR DESCRIPTION
@arch/arm64/boot/dts/rockchip/rk3399-nanopi4-common.dtsi
status is default set to disabled, change it to okay for enable rga.