### PR TITLE
Enable can1 interface at a nanopc-t6 board

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopi6-rev01.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopi6-rev01.dts
@@ -783,3 +783,7 @@
 	pinctrl-0 = <&uart8m1_xfer>;
 	status = "disabled";
 };
+
+&can1 {
+	status = "okay";
+};

--- a/drivers/net/can/rockchip/rockchip_can.c
+++ b/drivers/net/can/rockchip/rockchip_can.c
@@ -9,7 +9,6 @@
 #include <linux/can.h>
 #include <linux/can/dev.h>
 #include <linux/can/error.h>
-#include <linux/can/led.h>
 #include <linux/clk.h>
 #include <linux/netdevice.h>
 #include <linux/interrupt.h>
@@ -309,7 +308,7 @@ static int rockchip_can_start_xmit(struct sk_buff *skb, struct net_device *ndev)
 	}
 
 	writel(fi, rcan->base + CAN_TX_FRM_INFO);
-	can_put_echo_skb(skb, ndev, 0);
+	can_put_echo_skb(skb, ndev, 0, 0);
 
 	rockchip_can_write_cmdreg(rcan, TX_REQ);
 	netdev_dbg(ndev, "TX: can_id:0x%08x dlc: %d mode: 0x%08x data: 0x%08x 0x%08x\n",
@@ -334,7 +333,7 @@ static void rockchip_can_rx(struct net_device *ndev)
 		return;
 
 	fi = readl(rcan->base + CAN_RX_FRM_INFO);
-	cf->can_dlc = get_can_dlc(fi & CAN_DLC_MASK);
+	cf->can_dlc = can_cc_dlc2len(fi & CAN_DLC_MASK);
 	id = readl(rcan->base + CAN_RX_ID);
 	if (fi & CAN_EFF)
 		id |= CAN_EFF_FLAG;
@@ -354,8 +353,6 @@ static void rockchip_can_rx(struct net_device *ndev)
 	stats->rx_packets++;
 	stats->rx_bytes += cf->can_dlc;
 	netif_rx(skb);
-
-	can_led_event(ndev, CAN_LED_EVENT_RX);
 
 	netdev_dbg(ndev, "%s can_id:0x%08x fi: 0x%08x dlc: %d data: 0x%08x 0x%08x\n",
 		   __func__, cf->can_id, fi, cf->can_dlc,
@@ -501,6 +498,7 @@ static irqreturn_t rockchip_can_interrupt(int irq, void *dev_id)
 	struct net_device *ndev = (struct net_device *)dev_id;
 	struct rockchip_can *rcan = netdev_priv(ndev);
 	struct net_device_stats *stats = &ndev->stats;
+	unsigned int dumy;
 	u8 err_int = ERR_WARN_INT | RX_BUF_OV | PASSIVE_ERR |
 		     TX_LOSTARB | BUS_ERR_INT;
 	u8 isr;
@@ -512,9 +510,8 @@ static irqreturn_t rockchip_can_interrupt(int irq, void *dev_id)
 				   CAN_DLC_MASK;
 		stats->tx_packets++;
 		rockchip_can_write_cmdreg(rcan, 0);
-		can_get_echo_skb(ndev, 0);
+		dumy = can_get_echo_skb(ndev, 0, NULL);
 		netif_wake_queue(ndev);
-		can_led_event(ndev, CAN_LED_EVENT_TX);
 	}
 
 	if (isr & RX_FINISH)
@@ -555,7 +552,6 @@ static int rockchip_can_open(struct net_device *ndev)
 		goto exit_can_start;
 	}
 
-	can_led_event(ndev, CAN_LED_EVENT_OPEN);
 	netif_start_queue(ndev);
 
 	netdev_dbg(ndev, "%s\n", __func__);
@@ -575,7 +571,6 @@ static int rockchip_can_close(struct net_device *ndev)
 	netif_stop_queue(ndev);
 	rockchip_can_stop(ndev);
 	close_candev(ndev);
-	can_led_event(ndev, CAN_LED_EVENT_STOP);
 	pm_runtime_put(rcan->dev);
 
 	netdev_dbg(ndev, "%s\n", __func__);
@@ -770,8 +765,6 @@ static int rockchip_can_probe(struct platform_device *pdev)
 			DRV_NAME, err);
 		goto err_disableclks;
 	}
-
-	devm_can_led_init(ndev);
 
 	pm_runtime_put(&pdev->dev);
 

--- a/drivers/net/can/rockchip/rockchip_canfd.c
+++ b/drivers/net/can/rockchip/rockchip_canfd.c
@@ -24,7 +24,6 @@
 #include <linux/types.h>
 #include <linux/can/dev.h>
 #include <linux/can/error.h>
-#include <linux/can/led.h>
 #include <linux/reset.h>
 #include <linux/pm_runtime.h>
 #include <linux/rockchip/cpu.h>
@@ -550,7 +549,7 @@ static int rockchip_canfd_start_xmit(struct sk_buff *skb,
 	if (cf->can_id & CAN_EFF_FLAG) {
 		/* Extended CAN ID format */
 		id = cf->can_id & CAN_EFF_MASK;
-		dlc = can_len2dlc(cf->len) & DLC_MASK;
+		dlc = can_fd_dlc2len(cf->len) & DLC_MASK;
 		dlc |= FORMAT_MASK;
 
 		/* Extended frames remote TX request */
@@ -559,7 +558,7 @@ static int rockchip_canfd_start_xmit(struct sk_buff *skb,
 	} else {
 		/* Standard CAN ID format */
 		id = cf->can_id & CAN_SFF_MASK;
-		dlc = can_len2dlc(cf->len) & DLC_MASK;
+		dlc = can_fd_dlc2len(cf->len) & DLC_MASK;
 
 		/* Standard frames remote TX request */
 		if (cf->can_id & CAN_RTR_FLAG)
@@ -596,7 +595,7 @@ static int rockchip_canfd_start_xmit(struct sk_buff *skb,
 		for (i = 0; i < cf->len; i += 4)
 			rockchip_canfd_write(rcan, CAN_TXDAT0 + i,
 					     *(u32 *)(cf->data + i));
-		can_put_echo_skb(skb, ndev, 0);
+		can_put_echo_skb(skb, ndev, 0, 0);
 		rockchip_canfd_write(rcan, CAN_CMD, CAN_TX1_REQ);
 		local_irq_restore(flags);
 		return NETDEV_TX_OK;
@@ -609,7 +608,7 @@ static int rockchip_canfd_start_xmit(struct sk_buff *skb,
 		rockchip_canfd_write(rcan, CAN_TXDAT0 + i,
 				     *(u32 *)(cf->data + i));
 
-	can_put_echo_skb(skb, ndev, 0);
+	can_put_echo_skb(skb, ndev, 0, 0);
 	rockchip_canfd_write(rcan, CAN_MODE,
 			     rockchip_canfd_read(rcan, CAN_MODE) | MODE_SPACE_RX);
 	rockchip_canfd_write(rcan, CAN_CMD, cmd);
@@ -664,9 +663,9 @@ static int rockchip_canfd_rx(struct net_device *ndev)
 
 	/* Change CAN data length format to socketCAN data format */
 	if (dlc & FDF_MASK)
-		cf->len = can_dlc2len(dlc & DLC_MASK);
+		cf->len = can_fd_dlc2len(dlc & DLC_MASK);
 	else
-		cf->len = get_can_dlc(dlc & DLC_MASK);
+		cf->len = can_cc_dlc2len(dlc & DLC_MASK);
 
 	/* Change CAN ID format to socketCAN ID format */
 	if (dlc & FORMAT_MASK) {
@@ -694,8 +693,6 @@ static int rockchip_canfd_rx(struct net_device *ndev)
 	stats->rx_packets++;
 	stats->rx_bytes += cf->len;
 	netif_rx(skb);
-
-	can_led_event(ndev, CAN_LED_EVENT_RX);
 
 	return 1;
 }
@@ -735,9 +732,6 @@ static int rockchip_canfd_rx_poll(struct napi_struct *napi, int quota)
 		while (work_done < quota)
 			work_done += rockchip_canfd_rx(ndev);
 	}
-
-	if (work_done)
-		can_led_event(ndev, CAN_LED_EVENT_RX);
 
 	if (work_done < 6) {
 		napi_complete_done(napi, work_done);
@@ -800,7 +794,7 @@ static int rockchip_canfd_err(struct net_device *ndev, u32 isr)
 		cancel_delayed_work(&rcan->tx_err_work);
 		netif_stop_queue(ndev);
 		rockchip_canfd_stop(ndev);
-		can_free_echo_skb(ndev, 0);
+		can_free_echo_skb(ndev, 0, NULL);
 		rockchip_canfd_start(ndev);
 		netif_start_queue(ndev);
 	}
@@ -817,6 +811,7 @@ static irqreturn_t rockchip_canfd_interrupt(int irq, void *dev_id)
 	struct net_device *ndev = (struct net_device *)dev_id;
 	struct rockchip_canfd *rcan = netdev_priv(ndev);
 	struct net_device_stats *stats = &ndev->stats;
+	unsigned int dumy;
 	u32 err_int = ERR_WARN_INT | RX_BUF_OV_INT | PASSIVE_ERR_INT |
 		      BUS_ERR_INT | BUS_OFF_INT;
 	u32 isr;
@@ -829,7 +824,7 @@ static irqreturn_t rockchip_canfd_interrupt(int irq, void *dev_id)
 		dlc = rockchip_canfd_read(rcan, CAN_TXFIC);
 		/* transmission complete interrupt */
 		if (dlc & FDF_MASK)
-			stats->tx_bytes += can_dlc2len(dlc & DLC_MASK);
+			stats->tx_bytes += can_fd_dlc2len(dlc & DLC_MASK);
 		else
 			stats->tx_bytes += (dlc & DLC_MASK);
 		stats->tx_packets++;
@@ -849,9 +844,8 @@ static irqreturn_t rockchip_canfd_interrupt(int irq, void *dev_id)
 					     0, 5000000, false, rcan, CAN_CMD))
 			netdev_err(ndev, "Warning: wait tx req timeout!\n");
 		rockchip_canfd_write(rcan, CAN_CMD, 0);
-		can_get_echo_skb(ndev, 0);
+		dumy = can_get_echo_skb(ndev, 0, NULL);
 		netif_wake_queue(ndev);
-		can_led_event(ndev, CAN_LED_EVENT_TX);
 	}
 
 	if (isr & RX_FINISH_INT) {
@@ -903,7 +897,6 @@ static int rockchip_canfd_open(struct net_device *ndev)
 		goto exit_can_start;
 	}
 
-	can_led_event(ndev, CAN_LED_EVENT_OPEN);
 	if (rcan->mode == ROCKCHIP_RK3568_CAN_MODE_V2)
 		napi_enable(&rcan->napi);
 	netif_start_queue(ndev);
@@ -927,7 +920,6 @@ static int rockchip_canfd_close(struct net_device *ndev)
 		napi_disable(&rcan->napi);
 	rockchip_canfd_stop(ndev);
 	close_candev(ndev);
-	can_led_event(ndev, CAN_LED_EVENT_STOP);
 	pm_runtime_put(rcan->dev);
 	cancel_delayed_work_sync(&rcan->tx_err_work);
 
@@ -1153,7 +1145,7 @@ static int rockchip_canfd_probe(struct platform_device *pdev)
 
 	if (rcan->mode == ROCKCHIP_RK3568_CAN_MODE_V2) {
 		rcan->txtorx = 0;
-		netif_napi_add(ndev, &rcan->napi, rockchip_canfd_rx_poll, 6);
+		netif_napi_add(ndev, &rcan->napi, rockchip_canfd_rx_poll);
 	}
 
 	ndev->netdev_ops = &rockchip_canfd_netdev_ops;
@@ -1182,8 +1174,6 @@ static int rockchip_canfd_probe(struct platform_device *pdev)
 			DRV_NAME, err);
 		goto err_disableclks;
 	}
-
-	devm_can_led_init(ndev);
 
 	return 0;
 


### PR DESCRIPTION
A nanopc-t6 board has 40-pin GPIO.  The can1 interface is connected to pin 29-CAN_RX_M0 and 31-CAN_TX_M0.  But it can't use in kernel 6.1.

It has three issue.
Issue 1.  Did not port driver code from kernel 5.10 to kernel 6.1.
Issue 2.  Did not enable device in dtb.
Issue 3.  Did not enable driver by kernel configs.

This PR fix issue 1 and 2.  The issue 3 shall fix by user configuration.

A rockchip_can.c did not test my self.  Because nanopc-t6 board - rk5588 uses rockchip_canfd.c only.  It could not test in this board.