### PR TITLE
hot fix scripts/mod/modpost: invalid option -- ‘M’

### DIFF
--- a/scripts/Makefile.modpost
+++ b/scripts/Makefile.modpost
@@ -41,7 +41,6 @@ include $(srctree)/scripts/Kbuild.include
 MODPOST = scripts/mod/modpost
 
 modpost-args =										\
-	$(if $(CONFIG_MODULES),-M)							\
 	$(if $(CONFIG_MODVERSIONS),-m)							\
 	$(if $(CONFIG_MODULE_SRCVERSION_ALL),-a)					\
 	$(if $(CONFIG_SECTION_MISMATCH_WARN_ONLY),,-E)					\


### PR DESCRIPTION
I tried to compile the xt_wgobfs module and encountered the problem scripts/mod/modpost: invalid option -- ‘M’. This is strange, as this function generally does not accept the -M parameter, and because of this, it is impossible to compile the kernel module. As I understand it, it is not mandatory, and disabling it (as a quick fix) should not have such a drastic effect on the process of working with modules.